### PR TITLE
Solved find_element_by_tag_name deprecated error

### DIFF
--- a/bing_scraper.py
+++ b/bing_scraper.py
@@ -187,6 +187,7 @@ class googleimagesdownload:
     def download_extended_page(self, url, chromedriver):
         from selenium import webdriver
         from selenium.webdriver.common.keys import Keys
+        from selenium.webdriver.common.by import By
         options = webdriver.ChromeOptions()
         options.add_argument('--no-sandbox')
         options.add_argument("--headless")
@@ -203,7 +204,7 @@ class googleimagesdownload:
         browser.get(url)
         time.sleep(0.5)
 
-        element = browser.find_element_by_tag_name("body")
+        element = browser.find_element(By.TAG_NAME, "body") # find_element_by_tag_name() has been deprecated
         pbar = tqdm(enumerate(range(30)), desc='Downloading HTML...', total=30)  # progress bar
         for _ in pbar:
             try:  # click 'see more' button if found


### PR DESCRIPTION
I encountered a very basic issue within this repository (While running `bing_scraper.py`) 

`'WebDriver' object has no attribute find_element_by_tag_name`.  

______

Since `find_element_by_tag_name` has been depreciated in `Selenium`. 
Source 1: [Official Documentation Link](https://selenium-python.readthedocs.io/locating-elements.html#locating-elements-by-tag-name)
Source 2: [GitHub Issue](https://github.com/oxylabs/Scraping-Dynamic-JavaScript-Ajax-Websites-With-BeautifulSoup/issues/1#:~:text=element%20%3D%20driver.find_element_by_tag_name(%22small%22))

The alternative approach is to use `find_element(By.TAG_NAME, "your_html_tag")`, as I have updated the `bing_scraper.py`, Kindly review it.

Thank you!

I have read the CLA Document and I sign the CLA

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced compatibility for Bing image scraper with latest Selenium practices.

### 📊 Key Changes
- Imported `By` class from the `selenium.webdriver.common.by` module.
- Replaced the deprecated `find_element_by_tag_name` with the updated `find_element` method, utilizing the `By` class for specifying the element search criteria.

### 🎯 Purpose & Impact
- **Purpose:** The update ensures that the Bing scraper in the repository is using the latest Selenium methods, maintaining compatibility with newer versions of the Selenium package.
- **Impact:** Users of the scraper will benefit from code that adheres to the current best practices, potentially resulting in more reliable scraping and less maintenance work due to deprecated functionality. 🛠️🔄