### PR TITLE
Set CI workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
## Summary
- add explicit `contents: read` permissions to the CI workflow

## CodeQL alerts
Addresses https://github.com/ultralytics/google-images-download/security/code-scanning/1

## Validation
- Parsed workflow YAML with `yaml.safe_load()`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR updates the GitHub Actions CI workflow to explicitly grant read-only access to repository contents for improved security and clearer permission control.

### 📊 Key Changes
- Added a top-level `permissions` block to `.github/workflows/ci.yml`
- Set `contents: read` for the CI workflow
- Left the existing CI trigger behavior unchanged for pull requests targeting `main`

### 🎯 Purpose & Impact
- Improves security by following GitHub Actions best practices and limiting workflow permissions to only what CI needs 🛡️
- Reduces the risk of accidental or unnecessary write access during automated checks
- Makes the workflow’s access level more explicit and easier to audit for maintainers 👀
- Should have little to no visible impact for end users, but helps keep project automation safer and more maintainable ✅