### PR TITLE
Bump actions/checkout from v4 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Bump actions/checkout from v4 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step from `actions/checkout@v4` to `actions/checkout@v6` in the CI workflow.

### 📊 Key Changes
- ⬆️ Upgraded the `actions/checkout` GitHub Action in `.github/workflows/ci.yml`
- 🛠️ Changed the CI workflow dependency from version `v4` to `v6`
- ✅ No application code or user-facing features were modified

### 🎯 Purpose & Impact
- 🔒 Helps keep CI infrastructure current with the latest GitHub Actions improvements and maintenance updates
- 🚀 May improve workflow reliability, compatibility, and long-term support in automated testing
- 👥 Has little to no direct impact on end users, but benefits contributors by keeping repository automation up to date