### PR TITLE
Bump actions/setup-python from v5 to v6 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
Bump actions/setup-python from v5 to v6 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR makes a small maintenance update by upgrading the GitHub Actions Python setup step from `actions/setup-python@v5` to `@v6` in the CI workflow.

### 📊 Key Changes
- Updated the CI workflow file `.github/workflows/ci.yml`.
- Changed the GitHub Action used for Python setup:
  - from `actions/setup-python@v5`
  - to `actions/setup-python@v6`
- No application code, features, or user-facing behavior were changed.

### 🎯 Purpose & Impact
- ✅ Keeps the repository’s CI pipeline up to date with the latest supported GitHub Action version.
- 🛠️ May improve reliability, compatibility, and long-term maintainability of automated testing.
- 🔒 Helps the project stay aligned with current GitHub Actions best practices and security updates.
- 👥 Minimal impact for end users, but beneficial for maintainers by reducing risk of CI issues over time.