### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ Contributions from the community are highly encouraged and appreciated! Your inp
 
 We also invite you to participate in our [Survey](https://www.ultralytics.com/survey?utm_source=github&utm_medium=social&utm_campaign=Survey) to share your feedback, helping us understand your needs and improve our offerings. A heartfelt thank you 🙏 to all our contributors for their dedication and support!
 
-[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
+[![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/google-images-download/graphs/contributors)
 
 ## 🔏 License
 
 Ultralytics provides two licensing options to accommodate different usage needs:
 
-- **AGPL-3.0 License**: Ideal for students, researchers, and enthusiasts working on open-source projects. It promotes collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/ultralytics/blob/main/LICENSE) file for full details.
+- **AGPL-3.0 License**: Ideal for students, researchers, and enthusiasts working on open-source projects. It promotes collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/google-images-download/blob/main/LICENSE) file for full details.
 - **Enterprise License**: Designed for commercial use cases, this license allows integration of Ultralytics software into proprietary products and services without the open-source requirements of AGPL-3.0. For more information, visit [Ultralytics Licensing](https://www.ultralytics.com/license).
 
 ## 📬 Contact


### PR DESCRIPTION
## Summary
- retargets the README contributors link to this repository
- retargets the README license link to this repository's LICENSE file

## Validation
- git diff --check
- codespell README.md
- lychee README.md
- python -m compileall -q .
- pytest -q

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🛠️ This PR updates the README so repository links correctly point to `ultralytics/google-images-download` instead of the main `ultralytics/ultralytics` repo.

### 📊 Key Changes
- Fixed the **contributors badge link** to open the correct contributors page for [`ultralytics/google-images-download`](https://github.com/ultralytics/google-images-download/graphs/contributors).
- Updated the **AGPL-3.0 license link** to point to the correct [`LICENSE` file in this repository](https://github.com/ultralytics/google-images-download/blob/main/LICENSE).
- No code, functionality, or package behavior was changed — this is a **documentation-only cleanup** 📘.

### 🎯 Purpose & Impact
- Improves README accuracy by ensuring users are sent to the **right repository resources** 🔗.
- Makes it easier for contributors and users to find the correct **project-specific contributors list and license details**.
- Helps reduce confusion caused by links that previously pointed to the unrelated main Ultralytics repo ✅.
- Low risk change: affects **documentation only**, with no impact on runtime behavior or downloads 🚀