### PR TITLE
Bump actions/checkout from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Bump actions/checkout from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions checkout step in CI from `actions/checkout@v6` to `actions/checkout@v7`.

### 📊 Key Changes
- ⬆️ Upgraded the CI workflow dependency in `.github/workflows/ci.yml`
- 🔧 Replaced `actions/checkout@v6` with `actions/checkout@v7`
- 🤖 No application code or user-facing features were changed

### 🎯 Purpose & Impact
- ✅ Keeps the repository’s CI workflow aligned with the latest GitHub Actions version
- 🛡️ May improve security, compatibility, and long-term maintenance of automated tests
- 🚀 Helps ensure continued reliability of the project’s development workflow
- 👥 Minimal impact for end users, but useful for maintainers and contributors working with CI